### PR TITLE
Fix Spotify Downloader context downloads

### DIFF
--- a/COMPANION.md
+++ b/COMPANION.md
@@ -29,6 +29,8 @@ The service runs on `http://127.0.0.1:8937`.
 --prefer-video    Search for official videos instead of audio-only results
 --playlist-delay <seconds>
                   Wait between playlist tracks to reduce rate-limit pressure (default: 1.0)
+--retries <count>
+                  Retry failed track downloads after the first attempt (default: 2)
 ```
 
 Playlist downloads run as background jobs and save tracks in a playlist-specific subfolder under the configured output directory.

--- a/README.md
+++ b/README.md
@@ -65,12 +65,14 @@ Downloads are saved to `~/Music` by default.
 --prefer-video    Search for official videos instead of audio-only results
 --playlist-delay <seconds>
                   Wait between playlist tracks to reduce rate-limit pressure (default: 1.0)
+--retries <count>
+                  Retry failed track downloads after the first attempt (default: 2)
 ```
 
 Example:
 
 ```bash
-uv run python companion-service.py --output ~/Downloads/Music --prefer-video --playlist-delay 2
+uv run python companion-service.py --output ~/Downloads/Music --prefer-video --playlist-delay 2 --retries 2
 ```
 
 Playlist downloads are saved in a playlist-specific subfolder under the configured output directory.

--- a/companion-service.py
+++ b/companion-service.py
@@ -23,6 +23,7 @@ DOWNLOAD_DIR = str(Path.home() / "Music")
 TIMEOUT = 300  # 5 minutes
 PREFER_VIDEO = False  # set via --prefer-video flag
 PLAYLIST_DELAY = 1.0
+DOWNLOAD_RETRIES = 2
 DOWNLOAD_LOCK = threading.Lock()
 JOBS_LOCK = threading.Lock()
 QUEUE_CONDITION = threading.Condition()
@@ -326,46 +327,65 @@ class DownloadHandler(BaseHTTPRequestHandler):
             "--print", "after_move:%(title)s",
         ]
 
-        try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=TIMEOUT
-            )
-        except subprocess.TimeoutExpired:
-            return {"success": False, "message": "Download timed out"}
+        max_attempts = DOWNLOAD_RETRIES + 1
+        last_failure = {"success": False, "message": "Download failed"}
 
-        if result.returncode != 0:
-            return {
-                "success": False,
-                "message": "yt-dlp download failed",
-                "error": result.stderr,
-            }
-
-        matched_title = result.stdout.strip()
-
-        # Find the downloaded file
-        output_file = Path(output_dir) / f"{filename}.mp3"
-        if not output_file.exists():
-            candidates = list(Path(output_dir).glob(f"{filename}.*"))
-            if candidates:
-                output_file = candidates[0]
+        for attempt in range(1, max_attempts + 1):
+            try:
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, timeout=TIMEOUT
+                )
+            except subprocess.TimeoutExpired:
+                last_failure = {"success": False, "message": "Download timed out"}
             else:
-                return {
-                    "success": False,
-                    "message": "Download completed but output file not found",
-                }
+                if result.returncode != 0:
+                    last_failure = {
+                        "success": False,
+                        "message": "yt-dlp download failed",
+                        "error": result.stderr,
+                    }
+                else:
+                    matched_title = result.stdout.strip()
 
-        # Embed Spotify metadata
-        try:
-            DownloadHandler._embed_metadata(output_file, metadata)
-        except Exception as e:
-            print(f"Warning: Failed to embed metadata: {e}")
+                    # Find the downloaded file
+                    output_file = Path(output_dir) / f"{filename}.mp3"
+                    if not output_file.exists():
+                        candidates = list(Path(output_dir).glob(f"{filename}.*"))
+                        if candidates:
+                            output_file = candidates[0]
+                        else:
+                            last_failure = {
+                                "success": False,
+                                "message": "Download completed but output file not found",
+                            }
+                            if attempt < max_attempts:
+                                time.sleep(min(2 * attempt, 10))
+                            continue
 
-        return {
-            "success": True,
-            "message": "Download completed successfully",
-            "matched": matched_title,
-            "file": str(output_file),
-        }
+                    # Embed Spotify metadata
+                    try:
+                        DownloadHandler._embed_metadata(output_file, metadata)
+                    except Exception as e:
+                        print(f"Warning: Failed to embed metadata: {e}")
+
+                    return {
+                        "success": True,
+                        "message": "Download completed successfully",
+                        "matched": matched_title,
+                        "file": str(output_file),
+                        "attempts": attempt,
+                    }
+
+            if attempt < max_attempts:
+                print(
+                    f"Retrying download for {query} "
+                    f"({attempt}/{max_attempts - 1} retries used): "
+                    f"{last_failure.get('message', 'Download failed')}"
+                )
+                time.sleep(min(2 * attempt, 10))
+
+        last_failure["attempts"] = max_attempts
+        return last_failure
 
     @staticmethod
     def _embed_metadata(file_path, metadata):
@@ -455,7 +475,7 @@ class DownloadHandler(BaseHTTPRequestHandler):
 
 
 def main():
-    global PREFER_VIDEO, DOWNLOAD_DIR, PLAYLIST_DELAY
+    global PREFER_VIDEO, DOWNLOAD_DIR, PLAYLIST_DELAY, DOWNLOAD_RETRIES
 
     parser = argparse.ArgumentParser(description="Spotify Downloader Companion Service")
     parser.add_argument("--prefer-video", action="store_true", help="Prefer official video over audio-only results")
@@ -466,11 +486,18 @@ def main():
         default=PLAYLIST_DELAY,
         help=f"Seconds to wait between playlist tracks (default: {PLAYLIST_DELAY})",
     )
+    parser.add_argument(
+        "--retries",
+        type=int,
+        default=DOWNLOAD_RETRIES,
+        help=f"Retries per track after the first attempt (default: {DOWNLOAD_RETRIES})",
+    )
     args = parser.parse_args()
 
     PREFER_VIDEO = args.prefer_video
     DOWNLOAD_DIR = args.output
     PLAYLIST_DELAY = max(0, args.playlist_delay)
+    DOWNLOAD_RETRIES = max(0, args.retries)
 
     missing = check_dependencies()
     if missing:
@@ -493,6 +520,7 @@ def main():
     print(f"  Download directory: {DOWNLOAD_DIR}")
     print(f"  Download mode: {'video' if PREFER_VIDEO else 'audio'}")
     print(f"  Playlist delay: {PLAYLIST_DELAY}s")
+    print(f"  Retries per track: {DOWNLOAD_RETRIES}")
     print("")
     print("Press Ctrl+C to stop the service")
     print("")

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -23,6 +23,62 @@ async function main() {
     explicit?: boolean;
   };
 
+  type CollectionKind = "playlist" | "album";
+
+  type CollectionDownload = {
+    kind: CollectionKind;
+    uri: string;
+    name: string;
+    tracks: DownloadMetadata[];
+    skipped: number;
+  };
+
+  function firstNonEmpty(...values: unknown[]): string {
+    for (const value of values) {
+      if (typeof value === "string" && value.trim()) return value.trim();
+    }
+    return "";
+  }
+
+  function asNumber(value: unknown): number | undefined {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim()) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+    return undefined;
+  }
+
+  function getSpotifyTrackUrl(uri: string): string {
+    return `https://open.spotify.com/track/${uri.split(":").pop()}`;
+  }
+
+  function parseSpotifyUri(uri: string | undefined): Spicetify.URI | null {
+    if (!uri) return null;
+    try {
+      return Spicetify.URI.fromString(uri);
+    } catch {
+      return null;
+    }
+  }
+
+  function resolveContextUri(uris: string[], contextUri: string | undefined, allowedTypes: string[]): string | null {
+    for (const candidate of [uris[0], contextUri]) {
+      const uri = parseSpotifyUri(candidate);
+      if (uri && allowedTypes.includes(uri.type)) {
+        return uri.toURI();
+      }
+    }
+    return null;
+  }
+
+  function mapArtistNames(items: any[] | undefined): string[] {
+    if (!Array.isArray(items)) return [];
+    return items
+      .map((artist: any) => firstNonEmpty(artist?.profile?.name, artist?.name, artist?.title))
+      .filter(Boolean);
+  }
+
   async function checkServiceHealth(): Promise<boolean> {
     try {
       const controller = new AbortController();
@@ -42,24 +98,31 @@ async function main() {
     const item = Spicetify.Player.data?.item;
     if (item?.uri === uri) {
       const meta: any = item.metadata ?? {};
+      const title = firstNonEmpty(item.name, meta.title, meta.name);
+      if (!title) throw new Error("Could not fetch track title");
+
       return {
-        title: item.name,
-        artist: item.artists?.map((a: any) => a.name).join(", ") ?? meta.artist_name ?? "",
+        title,
+        artist: mapArtistNames(item.artists).join(", ") || firstNonEmpty(meta.artist_name, meta["artist_name:1"]),
         album: item.album?.name ?? meta.album_title ?? "",
         album_artist: meta.album_artist_name ?? "",
-        track_number: parseInt(meta.album_track_number ?? "0") || undefined,
-        total_tracks: parseInt(meta.album_track_count ?? "0") || undefined,
-        disc_number: parseInt(meta.album_disc_number ?? "1") || undefined,
+        track_number: asNumber(meta.album_track_number),
+        total_tracks: asNumber(meta.album_track_count),
+        disc_number: asNumber(meta.album_disc_number),
         duration_ms: item.duration?.milliseconds,
         art_url: meta.image_xlarge_url ?? meta.image_large_url ?? meta.image_url,
         year: meta.album_release_year,
         date: meta.album_release_year,
-        spotify_url: `https://open.spotify.com/track/${uri.split(":").pop()}`,
+        spotify_url: getSpotifyTrackUrl(uri),
         explicit: item.isExplicit,
       };
     }
 
     // For non-playing tracks, use Spicetify's internal GraphQL
+    if (!Spicetify.GraphQL.Definitions.getTrackName || !Spicetify.GraphQL.Definitions.queryTrackArtists) {
+      throw new Error("Track GraphQL definitions are unavailable");
+    }
+
     let nameRes: any, artistsRes: any;
     try {
       [nameRes, artistsRes] = await Promise.all([
@@ -70,17 +133,17 @@ async function main() {
       throw new Error(`Failed to fetch track metadata: ${e?.message ?? JSON.stringify(e)}`);
     }
 
-    const title = nameRes?.data?.trackUnion?.name ?? "";
+    const trackUnion = artistsRes?.data?.trackUnion ?? nameRes?.data?.trackUnion;
+    const title = firstNonEmpty(nameRes?.data?.trackUnion?.name, trackUnion?.name, trackUnion?.title);
     if (!title) throw new Error("Could not fetch track title");
 
-    const trackUnion = artistsRes?.data?.trackUnion;
     const firstArtist = trackUnion?.firstArtist?.items ?? trackUnion?.artists?.items ?? [];
-    const artist = firstArtist.map((a: any) => a?.profile?.name ?? a?.name ?? "").filter(Boolean).join(", ");
+    const artist = mapArtistNames(firstArtist).join(", ");
 
     return {
       title,
       artist,
-      spotify_url: `https://open.spotify.com/track/${uri.split(":").pop()}`,
+      spotify_url: getSpotifyTrackUrl(uri),
     };
   }
 
@@ -95,7 +158,7 @@ async function main() {
     const itemV3 = item?.itemV3?.data;
     const uri = itemV2?.uri ?? itemV3?.uri;
 
-    if (!uri || !Spicetify.URI.isTrack(uri) || itemV2?.playability?.playable === false) {
+    if (!uri || !Spicetify.URI.isTrack(uri)) {
       return null;
     }
 
@@ -103,13 +166,9 @@ async function main() {
     if (!title) return null;
 
     const artistItems = itemV2?.artists?.items ?? itemV3?.identityTrait?.contributors?.items ?? [];
-    const artists = artistItems
-      .map((artist: any) => artist?.profile?.name ?? artist?.name ?? "")
-      .filter(Boolean);
+    const artists = mapArtistNames(artistItems);
     const album = itemV2?.albumOfTrack;
-    const albumArtists = album?.artists?.items
-      ?.map((artist: any) => artist?.profile?.name ?? "")
-      .filter(Boolean);
+    const albumArtists = mapArtistNames(album?.artists?.items);
     const releaseDate = itemV3?.identityTrait?.contentHierarchyParent?.publishingMetadataTrait?.firstPublishedAt?.isoString;
     const artUrl =
       getBestImageUrl(album?.coverArt?.sources) ??
@@ -130,7 +189,7 @@ async function main() {
       art_url: artUrl,
       year: releaseDate?.slice(0, 4),
       date: releaseDate?.slice(0, 10),
-      spotify_url: `https://open.spotify.com/track/${uri.split(":").pop()}`,
+      spotify_url: getSpotifyTrackUrl(uri),
       explicit: itemV2?.contentRating?.label === "EXPLICIT",
     };
   }
@@ -144,7 +203,7 @@ async function main() {
     );
   }
 
-  async function getPlaylistTracks(uri: string): Promise<{ name: string; tracks: DownloadMetadata[]; skipped: number }> {
+  async function getPlaylistTracks(uri: string): Promise<CollectionDownload> {
     const fetchPlaylistContents = Spicetify.GraphQL.Definitions.fetchPlaylistContents;
     if (!fetchPlaylistContents) {
       throw new Error("Playlist GraphQL definition is unavailable");
@@ -186,14 +245,253 @@ async function main() {
       offset += items.length;
     }
 
-    return { name: playlistName, tracks, skipped };
+    return { kind: "playlist", uri, name: playlistName, tracks, skipped };
   }
 
-  async function downloadSong(uris: string[]) {
+  function getAlbumRoot(response: any): any {
+    return (
+      response?.data?.albumUnion ??
+      response?.data?.album ??
+      response?.data?.getAlbum ??
+      response?.data?.albumMetadata ??
+      response?.data?.entityUnion ??
+      response?.data
+    );
+  }
+
+  function getAlbumName(response: any, uri: string): string {
+    const album = getAlbumRoot(response);
+    return firstNonEmpty(
+      album?.name,
+      album?.title,
+      album?.metadata?.name,
+      album?.identityTrait?.name,
+      `Album ${uri.split(":").pop()}`
+    );
+  }
+
+  function getAlbumArtists(album: any): string[] {
+    const candidates = [
+      mapArtistNames(album?.artists?.items),
+      mapArtistNames(album?.artists),
+      mapArtistNames(album?.metadata?.artists?.items),
+    ];
+    return candidates.find((artists) => artists.length > 0) ?? [];
+  }
+
+  function getAlbumReleaseDate(album: any): string {
+    return firstNonEmpty(
+      album?.date?.isoString,
+      album?.releaseDate?.isoString,
+      album?.releaseDate,
+      album?.metadata?.releaseDate?.isoString,
+      album?.metadata?.releaseDate
+    );
+  }
+
+  function getAlbumArtUrl(album: any): string | undefined {
+    return (
+      getBestImageUrl(album?.coverArt?.sources) ??
+      getBestImageUrl(album?.visualIdentityTrait?.squareCoverImage?.image?.data?.sources) ??
+      getBestImageUrl(album?.metadata?.coverArt?.sources)
+    );
+  }
+
+  function getAlbumTrackContainers(album: any): any[] {
+    return [
+      album?.tracksV2,
+      album?.tracks,
+      album?.trackList,
+      album?.items,
+      album?.data?.tracksV2,
+      album?.data?.tracks,
+    ].filter(Boolean);
+  }
+
+  function extractAlbumTrackItems(response: any): any[] {
+    const album = getAlbumRoot(response);
+    const directItems: any[] = [];
+    for (const container of getAlbumTrackContainers(album)) {
+      const items = container?.items ?? container;
+      if (Array.isArray(items)) {
+        directItems.push(...items);
+      } else if (items) {
+        directItems.push(items);
+      }
+    }
+
+    const discItems: any[] = [];
+    const discs = album?.discs?.items ?? album?.discs ?? [];
+    if (Array.isArray(discs)) {
+      for (const disc of discs) {
+        const tracks = disc?.tracks?.items ?? disc?.tracks ?? [];
+        if (Array.isArray(tracks)) discItems.push(...tracks);
+      }
+    }
+
+    const uriItems = response?.data?.albumUnion?.trackUris ?? response?.data?.trackUris ?? [];
+    const items = [...directItems, ...discItems, ...uriItems];
+    return items.filter(Boolean);
+  }
+
+  function getAlbumTotalCount(response: any, itemCount: number): number | undefined {
+    const album = getAlbumRoot(response);
+    for (const container of getAlbumTrackContainers(album)) {
+      const total = asNumber(
+        container?.totalCount ??
+          container?.total ??
+          container?.pagingInfo?.totalItems ??
+          container?.pagingInfo?.totalCount
+      );
+      if (total !== undefined) return total;
+    }
+    return asNumber(album?.tracks?.totalCount ?? album?.tracksV2?.totalCount) ?? (itemCount ? itemCount : undefined);
+  }
+
+  function getTrackUriFromAlbumItem(item: any): string {
+    if (typeof item === "string" && Spicetify.URI.isTrack(item)) return item;
+    return firstNonEmpty(
+      item?.uri,
+      item?.trackUri,
+      item?.track?.uri,
+      item?.track?.data?.uri,
+      item?.trackV2?.data?.uri,
+      item?.itemV2?.data?.uri,
+      item?.itemV3?.data?.uri,
+      item?.data?.uri
+    );
+  }
+
+  function getAlbumTrackMetadata(item: any, album: any, totalTracks?: number): DownloadMetadata | null {
+    const track = item?.track?.data ?? item?.track ?? item?.trackV2?.data ?? item?.itemV2?.data ?? item?.itemV3?.data ?? item?.data ?? item;
+    const uri = getTrackUriFromAlbumItem(item);
+
+    if (!uri || !Spicetify.URI.isTrack(uri)) {
+      return null;
+    }
+
+    const title = firstNonEmpty(track?.name, track?.title, track?.identityTrait?.name);
+    if (!title) return null;
+
+    const artists = mapArtistNames(
+      track?.artists?.items ??
+        track?.artists ??
+        track?.identityTrait?.contributors?.items ??
+        track?.contributors?.items
+    );
+    const albumArtists = getAlbumArtists(album);
+    const releaseDate = getAlbumReleaseDate(album);
+
+    return {
+      title,
+      artist: artists.join(", "),
+      album: firstNonEmpty(album?.name, album?.title, album?.identityTrait?.name),
+      album_artist: albumArtists.join(", "),
+      track_number: asNumber(track?.trackNumber ?? item?.trackNumber),
+      total_tracks: totalTracks,
+      disc_number: asNumber(track?.discNumber ?? item?.discNumber),
+      duration_ms: asNumber(track?.trackDuration?.totalMilliseconds ?? track?.duration?.totalMilliseconds ?? track?.duration?.milliseconds),
+      art_url: getAlbumArtUrl(album),
+      year: releaseDate.slice(0, 4) || undefined,
+      date: releaseDate.slice(0, 10) || undefined,
+      spotify_url: getSpotifyTrackUrl(uri),
+      explicit: track?.contentRating?.label === "EXPLICIT" || track?.isExplicit === true,
+    };
+  }
+
+  async function requestAlbumPage(uri: string, offset: number): Promise<any> {
+    const definitions = [
+      Spicetify.GraphQL.Definitions.queryAlbumTracks,
+      Spicetify.GraphQL.Definitions.getAlbumNameAndTracks,
+      Spicetify.GraphQL.Definitions.getAlbum,
+      Spicetify.GraphQL.Definitions.queryAlbumTrackUris,
+    ].filter(Boolean);
+
+    if (definitions.length === 0) {
+      throw new Error("Album GraphQL definitions are unavailable");
+    }
+
+    let lastError: unknown;
+    for (const definition of definitions) {
+      try {
+        const response = await Spicetify.GraphQL.Request(definition, {
+          uri,
+          albumUri: uri,
+          offset,
+          limit: PLAYLIST_PAGE_SIZE,
+          locale: Spicetify.Locale?.getLocale?.() ?? "",
+        });
+
+        if (!response?.errors && extractAlbumTrackItems(response).length > 0) {
+          return response;
+        }
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    if (lastError instanceof Error) throw lastError;
+    throw new Error("No album tracks returned");
+  }
+
+  async function getAlbumTracks(uri: string): Promise<CollectionDownload> {
+    let offset = 0;
+    let totalCount: number | undefined;
+    let albumName = `Album ${uri.split(":").pop()}`;
+    let skipped = 0;
+    const tracks: DownloadMetadata[] = [];
+    const seenUris = new Set<string>();
+
+    while (totalCount === undefined || offset < totalCount) {
+      const response = await requestAlbumPage(uri, offset);
+      const album = getAlbumRoot(response);
+      const items = extractAlbumTrackItems(response);
+      if (offset === 0) albumName = getAlbumName(response, uri);
+      totalCount = getAlbumTotalCount(response, items.length);
+
+      for (const item of items) {
+        const trackUri = getTrackUriFromAlbumItem(item);
+        if (trackUri && seenUris.has(trackUri)) continue;
+        if (trackUri) seenUris.add(trackUri);
+
+        let metadata = getAlbumTrackMetadata(item, album, totalCount);
+        if (!metadata && trackUri) {
+          try {
+            metadata = await getTrackMetadata(trackUri);
+            metadata.album = metadata.album || albumName;
+            metadata.total_tracks = metadata.total_tracks ?? totalCount;
+          } catch {
+            metadata = null;
+          }
+        }
+
+        if (metadata) {
+          metadata.album = metadata.album || albumName;
+          metadata.total_tracks = metadata.total_tracks ?? totalCount;
+          tracks.push(metadata);
+        } else {
+          skipped += 1;
+        }
+      }
+
+      if (items.length === 0 || totalCount === undefined || offset + items.length >= totalCount) break;
+      offset += items.length;
+    }
+
+    return { kind: "album", uri, name: albumName, tracks, skipped };
+  }
+
+  async function downloadSong(uris: string[], _uids?: string[], contextUri?: string) {
+    const trackUri = resolveContextUri(uris, contextUri, [Spicetify.URI.Type.TRACK]);
+    if (!trackUri) {
+      Spicetify.showNotification("Spotify Downloader could not find a track to download.", true, 5000);
+      return;
+    }
+
     const isServiceRunning = await checkServiceHealth();
 
     if (!isServiceRunning) {
-      const uriObject = Spicetify.URI.fromString(uris[0]);
+      const uriObject = Spicetify.URI.fromString(trackUri);
       const trackUrl = uriObject.toURL();
       await Spicetify.Platform.ClipboardAPI.copy(`yt-dlp "ytsearch1:${trackUrl}" -x --audio-format mp3`);
       Spicetify.showNotification("Companion service not running. Command copied to clipboard.", true, 3000);
@@ -203,9 +501,10 @@ async function main() {
     try {
       Spicetify.showNotification("Fetching track info...", false, 2000);
 
-      const metadata = await getTrackMetadata(uris[0]);
+      const metadata = await getTrackMetadata(trackUri);
 
-      Spicetify.showNotification(`Downloading: ${metadata.artist} - ${metadata.title}...`, false, 3000);
+      const label = metadata.artist ? `${metadata.artist} - ${metadata.title}` : metadata.title;
+      Spicetify.showNotification(`Downloading: ${label}...`, false, 3000);
 
       const controller = new AbortController();
       setTimeout(() => controller.abort(), 5 * 60 * 1000);
@@ -237,8 +536,23 @@ async function main() {
     }
   }
 
-  async function pollPlaylistJob(jobId: string) {
+  function formatFailedTracks(job: any): string {
+    if (!Array.isArray(job?.failures) || job.failures.length === 0) return "";
+
+    const names = job.failures
+      .map((failure: any) => firstNonEmpty(failure?.title, failure?.message))
+      .filter(Boolean)
+      .slice(0, 3);
+
+    if (names.length === 0) return "";
+
+    const remaining = Math.max(0, (job.failed ?? names.length) - names.length);
+    return ` Failed: ${names.join(", ")}${remaining ? `, +${remaining} more` : ""}.`;
+  }
+
+  async function pollCollectionJob(jobId: string, kind: CollectionKind) {
     let lastCompleted = -1;
+    const label = kind === "album" ? "Album" : "Playlist";
 
     while (true) {
       await new Promise((resolve) => setTimeout(resolve, JOB_POLL_INTERVAL_MS));
@@ -248,28 +562,75 @@ async function main() {
       const job = result?.job;
 
       if (!response.ok || !job) {
-        Spicetify.showNotification("Could not fetch playlist download status.", true, 5000);
+        Spicetify.showNotification(`Could not fetch ${kind} download status.`, true, 5000);
         return;
       }
 
       if (job.status === "completed" || job.status === "completed_with_errors") {
         const failed = job.failed ? `, ${job.failed} failed` : "";
-        Spicetify.showNotification(`Playlist download finished: ${job.completed}/${job.total}${failed}.`, !!job.failed, 8000);
+        Spicetify.showNotification(
+          `${label} download finished: ${job.completed}/${job.total}${failed}.${formatFailedTracks(job)}`,
+          !!job.failed,
+          10000
+        );
         return;
       }
 
       if (job.completed !== lastCompleted) {
         lastCompleted = job.completed;
         const current = job.current?.title ? ` Now: ${job.current.title}` : "";
-        Spicetify.showNotification(`Playlist download: ${job.completed}/${job.total}.${current}`, false, 3000);
+        Spicetify.showNotification(`${label} download: ${job.completed}/${job.total}.${current}`, false, 3000);
       }
     }
   }
 
-  async function downloadPlaylist(uris: string[]) {
-    const playlistUri = uris[0];
-    const isServiceRunning = await checkServiceHealth();
+  async function downloadCollection(collection: CollectionDownload) {
+    try {
+      if (collection.tracks.length === 0) {
+        Spicetify.showNotification(`No downloadable tracks found in this ${collection.kind}.`, true, 5000);
+        return;
+      }
 
+      const skipped = collection.skipped ? ` (${collection.skipped} skipped)` : "";
+      Spicetify.showNotification(`Queueing ${collection.tracks.length} ${collection.kind} tracks${skipped}...`, false, 4000);
+
+      const response = await fetch(`${COMPANION_SERVICE_URL}/download/playlist`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          playlist: { uri: collection.uri, name: collection.name },
+          tracks: collection.tracks,
+        }),
+      });
+
+      const result = await response.json();
+      if (!response.ok || !result.success) {
+        Spicetify.showNotification(`${collection.kind} download failed: ${result.message ?? "Unknown error"}`, true, 5000);
+        return;
+      }
+
+      Spicetify.showNotification(`${collection.kind} download queued: ${result.total} tracks.`, false, 5000);
+      pollCollectionJob(result.job_id, collection.kind).catch((error) => {
+        const msg = error instanceof Error ? error.message : "Unknown error";
+        Spicetify.showNotification(`${collection.kind} status error: ${msg}`, true, 5000);
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : "Unknown error";
+      Spicetify.showNotification(`${collection.kind} download error: ${msg}`, true, 5000);
+    }
+  }
+
+  async function downloadPlaylist(uris: string[], _uids?: string[], contextUri?: string) {
+    const playlistUri = resolveContextUri(uris, contextUri, [
+      Spicetify.URI.Type.PLAYLIST,
+      Spicetify.URI.Type.PLAYLIST_V2,
+    ]);
+    if (!playlistUri) {
+      Spicetify.showNotification("Spotify Downloader could not find a playlist to download.", true, 5000);
+      return;
+    }
+
+    const isServiceRunning = await checkServiceHealth();
     if (!isServiceRunning) {
       Spicetify.showNotification("Companion service is required for playlist downloads.", true, 5000);
       return;
@@ -277,68 +638,74 @@ async function main() {
 
     try {
       Spicetify.showNotification("Fetching playlist tracks...", false, 3000);
-      const playlist = await getPlaylistTracks(playlistUri);
-
-      if (playlist.tracks.length === 0) {
-        Spicetify.showNotification("No downloadable tracks found in this playlist.", true, 5000);
-        return;
-      }
-
-      const skipped = playlist.skipped ? ` (${playlist.skipped} skipped)` : "";
-      Spicetify.showNotification(`Queueing ${playlist.tracks.length} playlist tracks${skipped}...`, false, 4000);
-
-      const response = await fetch(`${COMPANION_SERVICE_URL}/download/playlist`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          playlist: { uri: playlistUri, name: playlist.name },
-          tracks: playlist.tracks,
-        }),
-      });
-
-      const result = await response.json();
-      if (!response.ok || !result.success) {
-        Spicetify.showNotification(`Playlist download failed: ${result.message ?? "Unknown error"}`, true, 5000);
-        return;
-      }
-
-      Spicetify.showNotification(`Playlist download queued: ${result.total} tracks.`, false, 5000);
-      pollPlaylistJob(result.job_id).catch((error) => {
-        const msg = error instanceof Error ? error.message : "Unknown error";
-        Spicetify.showNotification(`Playlist status error: ${msg}`, true, 5000);
-      });
+      await downloadCollection(await getPlaylistTracks(playlistUri));
     } catch (error) {
       const msg = error instanceof Error ? error.message : "Unknown error";
       Spicetify.showNotification(`Playlist download error: ${msg}`, true, 5000);
     }
   }
 
-  function shouldDisplayContextMenu(uris: string[]) {
-    return Spicetify.URI.isTrack(uris[0]);
+  async function downloadAlbum(uris: string[], _uids?: string[], contextUri?: string) {
+    const albumUri = resolveContextUri(uris, contextUri, [Spicetify.URI.Type.ALBUM]);
+    if (!albumUri) {
+      Spicetify.showNotification("Spotify Downloader could not find an album to download.", true, 5000);
+      return;
+    }
+
+    const isServiceRunning = await checkServiceHealth();
+    if (!isServiceRunning) {
+      Spicetify.showNotification("Companion service is required for album downloads.", true, 5000);
+      return;
+    }
+
+    try {
+      Spicetify.showNotification("Fetching album tracks...", false, 3000);
+      await downloadCollection(await getAlbumTracks(albumUri));
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : "Unknown error";
+      Spicetify.showNotification(`Album download error: ${msg}`, true, 5000);
+    }
   }
 
-  function shouldDisplayPlaylistContextMenu(uris: string[]) {
-    if (uris.length !== 1) return false;
-    const uri = Spicetify.URI.fromString(uris[0]);
-    return uri.type === Spicetify.URI.Type.PLAYLIST || uri.type === Spicetify.URI.Type.PLAYLIST_V2;
+  function shouldDisplayContextMenu(uris: string[], _uids?: string[], contextUri?: string) {
+    return !!resolveContextUri(uris, contextUri, [Spicetify.URI.Type.TRACK]);
+  }
+
+  function shouldDisplayPlaylistContextMenu(uris: string[], _uids?: string[], contextUri?: string) {
+    return !!resolveContextUri(uris, contextUri, [
+      Spicetify.URI.Type.PLAYLIST,
+      Spicetify.URI.Type.PLAYLIST_V2,
+    ]);
+  }
+
+  function shouldDisplayAlbumContextMenu(uris: string[], _uids?: string[], contextUri?: string) {
+    return !!resolveContextUri(uris, contextUri, [Spicetify.URI.Type.ALBUM]);
   }
 
   const songContextMenu = new Spicetify.ContextMenu.Item(
-    "Download song",
+    "Download song (SD)",
     downloadSong,
     shouldDisplayContextMenu,
     "download"
   );
 
   const playlistContextMenu = new Spicetify.ContextMenu.Item(
-    "Download playlist",
+    "Download playlist (SD)",
     downloadPlaylist,
     shouldDisplayPlaylistContextMenu,
     "download"
   );
 
+  const albumContextMenu = new Spicetify.ContextMenu.Item(
+    "Download album (SD)",
+    downloadAlbum,
+    shouldDisplayAlbumContextMenu,
+    "download"
+  );
+
   songContextMenu.register();
   playlistContextMenu.register();
+  albumContextMenu.register();
 }
 
 export default main;


### PR DESCRIPTION
Done #11

## Summary
- Separates Spotify Downloader menu actions from Spotify's native Premium download action with shorter `(SD)` labels.
- Makes track metadata extraction more reliable so context-menu downloads do not fail with missing titles.
- Adds album support and improves playlist/album queue progress and failure details.
- Adds retry support in the companion service for transient yt-dlp failures.

## Validation
- `python3 -m py_compile companion-service.py`
- `python3 companion-service.py --help`
- `npx tsc --noEmit`
- `npm run build-local`